### PR TITLE
feat: receive stream stats on the signalling websocket, and use it as a heartbeat

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "orogen",
+            "request": "launch",
+            "name": "(d/o/video_streamer_webrtc) video_streamer_webrtc::StreamerTask",
+            "deploy": "video_streamer_webrtc::StreamerTask",
+            "deployAs": "streamer",
+            "environment": [
+                { "name": "GST_VAAPI_ALL_DRIVERS", "value": "1" }
+
+            ]
+        }
+    ]
+}

--- a/examples/run.html
+++ b/examples/run.html
@@ -32,6 +32,20 @@
 
       function onAddRemoteStream(event) {
         html5VideoElement.srcObject = event.streams[0];
+
+        let intervalToken = setInterval(
+          async () => {
+            let stats = await webrtcPeerConnection.getStats();
+            if (websocketConnection.readyState == 3) {
+                clearInterval(intervalToken);
+            }
+            else {
+                let array = []
+                stats.forEach((s) => array.push(s))
+                websocketConnection.send(JSON.stringify({ "type": "stats", "data": array }));
+            }
+          }, 1000
+        )
       }
 
 

--- a/examples/run.html
+++ b/examples/run.html
@@ -2,6 +2,7 @@
   <head>
     <script type="text/javascript" src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
     <script type="text/javascript">
+      var sendHeartbeat = true;
       var html5VideoElement;
       var websocketConnection;
       var webrtcPeerConnection;
@@ -39,7 +40,7 @@
             if (websocketConnection.readyState == 3) {
                 clearInterval(intervalToken);
             }
-            else {
+            else if (sendHeartbeat) {
                 let array = []
                 stats.forEach((s) => array.push(s))
                 websocketConnection.send(JSON.stringify({ "type": "stats", "data": array }));

--- a/manifest.xml
+++ b/manifest.xml
@@ -13,4 +13,5 @@
   <depend package="gstreamer-webrtc" />
   <depend package="gstreamer-vaapi" />
   <depend package="gstreamer-plugins-bad" />
+  <depend package="jsoncpp"/>
 </package>

--- a/tasks/StreamerTask.cpp
+++ b/tasks/StreamerTask.cpp
@@ -130,12 +130,13 @@ Receiver* create_receiver(SoupWebsocketConnection * connection, StreamerTask& ta
         <<    ",payload=" << RTP_PAYLOAD_TYPE
         << "! webrtcbin.";
 
-    std::cout << "Using pipeline: " << pipelineDefinition.str() << std::endl;
+    LOG_INFO_S << "using pipeline: " << pipelineDefinition.str() << std::endl;
 
     GError* error = nullptr;
     receiver->pipeline = gst_parse_launch(pipelineDefinition.str().c_str(), &error);
     if (error) {
-        g_warning ("Could not create WebRTC pipeline: %s\n", error->message);
+        LOG_ERROR_S << "could not create WebRTC pipeline: "
+                    << error->message << std::endl;
         g_error_free (error);
         return nullptr;
     }
@@ -333,13 +334,13 @@ void handleSDPMessage(Receiver* receiver, Json::Value data) {
 
 void handleICEMessage(Receiver* receiver, Json::Value data) {
     if (data["sdpMLineIndex"].isNull()) {
-        g_error ("Received ICE message without mline index\n");
+        LOG_ERROR_S << "received ICE message without mline index" << std::endl;
         return;
     }
     guint mline_index = data["sdpMLineIndex"].asLargestUInt();
 
     if (data["candidate"].isNull()) {
-        g_error ("Received ICE message without ICE candidate string\n");
+        LOG_ERROR_S << "received ICE message without ICE candidate string" << std::endl;
         return;
     }
     string candidate = data["candidate"].asString();

--- a/tasks/StreamerTask.hpp
+++ b/tasks/StreamerTask.hpp
@@ -147,7 +147,8 @@ namespace video_streamer_webrtc{
         GMainContext *maincontext = nullptr;
         GMainLoop *mainloop = nullptr;
 
-        std::map<SoupWebsocketConnection*, Receiver*> receivers;
+        typedef std::map<SoupWebsocketConnection*, Receiver*> ReceiverMap;
+        ReceiverMap receivers;
         void startReceiver(Receiver& receiver);
         void configureFrameParameters(base::samples::frame::Frame const& frame);
         void clearAllReceivers();
@@ -161,12 +162,14 @@ namespace video_streamer_webrtc{
         void publishStats();
         void pushPendingFrames();
         void startReceivers();
+        void reapDeadReceivers();
 
         static int pauseServerCallback(StreamerTask* task);
         static int resumeServerCallback(StreamerTask* task);
         static int pushPendingFramesCallback(StreamerTask* task);
         static int startReceiversCallback(StreamerTask* task);
         static int publishStatsCallback(StreamerTask* task);
+        static int reapDeadReceiversCallback(StreamerTask* task);
 
         void queueIdleCallback(GSourceFunc callback);
     };

--- a/tasks/StreamerTask.hpp
+++ b/tasks/StreamerTask.hpp
@@ -158,6 +158,7 @@ namespace video_streamer_webrtc{
 
         void resumeServer();
         void pauseServer();
+        void publishStats();
         void pushPendingFrames();
         void startReceivers();
 
@@ -165,6 +166,7 @@ namespace video_streamer_webrtc{
         static int resumeServerCallback(StreamerTask* task);
         static int pushPendingFramesCallback(StreamerTask* task);
         static int startReceiversCallback(StreamerTask* task);
+        static int publishStatsCallback(StreamerTask* task);
 
         void queueIdleCallback(GSourceFunc callback);
     };

--- a/video_streamer_webrtc.orogen
+++ b/video_streamer_webrtc.orogen
@@ -1,13 +1,15 @@
-name 'video_streamer_webrtc'
+# frozen_string_literal: true
 
-using_library 'base-logging', typekit: false
-using_library 'gstreamer-webrtc-1.0', typekit: false
-using_library 'gstreamer-video-1.0', typekit: false
-using_library 'gstreamer-app-1.0', typekit: false
-using_library 'libsoup-2.4', typekit: false
-using_library 'json-glib-1.0', typekit: false
-import_types_from 'base'
-import_types_from 'video_streamer_webrtcTypes.hpp'
+name "video_streamer_webrtc"
+
+using_library "base-logging", typekit: false
+using_library "gstreamer-webrtc-1.0", typekit: false
+using_library "gstreamer-video-1.0", typekit: false
+using_library "gstreamer-app-1.0", typekit: false
+using_library "libsoup-2.4", typekit: false
+using_library "json-glib-1.0", typekit: false
+import_types_from "base"
+import_types_from "video_streamer_webrtcTypes.hpp"
 
 OroGen::Spec::Deployment.register_global_initializer(:gstreamer)
 if defined?(OroGen::Gen::RTT_CPP::Deployment)
@@ -32,27 +34,27 @@ if defined?(OroGen::Gen::RTT_CPP::Deployment)
     )
 end
 
-task_context 'StreamerTask' do
+task_context "StreamerTask" do
     needs_configuration
 
     needs_global_initializer :gstreamer
 
     # The target fps
-    property 'fps', 'int', 25
+    property "fps", "int", 25
 
     # The port on which the embedded server is listening
-    property 'port', 'int', 57_778
+    property "port", "int", 57_778
 
     # Encoding configuration (defaults to VP8)
-    property 'encoding', 'video_streamer_webrtc/Encoding'
+    property "encoding", "video_streamer_webrtc/Encoding"
 
     # STUN server (e.g. stun://10.128.0.1:3478)
-    property 'stun_server', 'string'
+    property "stun_server", "string"
 
     # The images to stream
-    input_port 'images', ro_ptr('/base/samples/frame/Frame')
+    input_port "images", ro_ptr("/base/samples/frame/Frame")
 
     port_driven
 
-    exception_states 'GSTREAMER_ERROR'
+    exception_states "GSTREAMER_ERROR"
 end

--- a/video_streamer_webrtc.orogen
+++ b/video_streamer_webrtc.orogen
@@ -7,7 +7,7 @@ using_library "gstreamer-webrtc-1.0", typekit: false
 using_library "gstreamer-video-1.0", typekit: false
 using_library "gstreamer-app-1.0", typekit: false
 using_library "libsoup-2.4", typekit: false
-using_library "json-glib-1.0", typekit: false
+using_library "jsoncpp", typekit: false
 import_types_from "base"
 import_types_from "video_streamer_webrtcTypes.hpp"
 

--- a/video_streamer_webrtc.orogen
+++ b/video_streamer_webrtc.orogen
@@ -51,6 +51,10 @@ task_context "StreamerTask" do
     # STUN server (e.g. stun://10.128.0.1:3478)
     property "stun_server", "string"
 
+    # How long will we keep a stream without receiving a heartbeat from the client
+    # on the signalling websocket
+    property "dead_receiver_timeout", "/base/Time"
+
     # The images to stream
     input_port "images", ro_ptr("/base/samples/frame/Frame")
 

--- a/video_streamer_webrtc.orogen
+++ b/video_streamer_webrtc.orogen
@@ -54,6 +54,10 @@ task_context "StreamerTask" do
     # The images to stream
     input_port "images", ro_ptr("/base/samples/frame/Frame")
 
+    # Statistics about the streams as received by our clients
+    output_port "client_statistics",
+                "/std/vector<video_streamer_webrtc/ClientStatistics>"
+
     port_driven
 
     exception_states "GSTREAMER_ERROR"

--- a/video_streamer_webrtcTypes.hpp
+++ b/video_streamer_webrtcTypes.hpp
@@ -38,18 +38,35 @@ namespace video_streamer_webrtc {
         uint16_t mtu = 0;
     };
 
+    /** Statistics on inbound video streams
+     *
+     * This is sent by our client(s) and logged here
+     */
     struct InboundStreamStatistics {
+        /** Bytes received so far */
         uint64_t rx_bytes = 0;
+        /** How many packets got discarded because of error correction */
         uint64_t packets_discarded_error_correction = 0;
+        /** How many packets have been received */
         uint64_t packets_received = 0;
+        /** How many duplicate packets have been received */
         uint64_t packets_duplicated = 0;
+        /** How many frames have been decoded */
         uint64_t frames_decoded = 0;
 
+        /** Timestamp of the last packet received */
         base::Time last_packet_received_timestamp;
 
+        /** How many indicators for "picture loss" were sent by the client back
+         * to us */
         uint64_t picture_loss_indicators_sent = 0;
+        /** How many indicators for "slice loss" were sent by the client back to
+         * us */
         uint64_t slice_loss_indicators_sent = 0;
+        /** How many I frame request were sent by the client back to us because
+         * of frame loss */
         uint64_t full_infra_requests_sent = 0;
+        /** How many NACKs have been sent by the client back to us */
         uint64_t nack_sent = 0;
     };
 

--- a/video_streamer_webrtcTypes.hpp
+++ b/video_streamer_webrtcTypes.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 #include <stdint.h>
+#include <base/Float.hpp>
+#include <base/Time.hpp>
 
 namespace video_streamer_webrtc {
     enum PREDEFINED_ENCODER {
@@ -34,6 +36,28 @@ namespace video_streamer_webrtc {
         std::string encoder_name;
         /** MTU of the network link */
         uint16_t mtu = 0;
+    };
+
+    struct InboundStreamStatistics {
+        uint64_t rx_bytes = 0;
+        uint64_t packets_discarded_error_correction = 0;
+        uint64_t packets_received = 0;
+        uint64_t packets_duplicated = 0;
+        uint64_t frames_decoded = 0;
+
+        base::Time last_packet_received_timestamp;
+
+        uint64_t picture_loss_indicators_sent = 0;
+        uint64_t slice_loss_indicators_sent = 0;
+        uint64_t full_infra_requests_sent = 0;
+        uint64_t nack_sent = 0;
+    };
+
+    /** All information related to our client */
+    struct ClientStatistics {
+        base::Time time;
+
+        std::vector<InboundStreamStatistics> inbound_stream_statistics;
     };
 }
 


### PR DESCRIPTION
This is meant to kill two birds with one stone:
- it allows us to log the video statistics along with the rest of the data
- it allows to detect dead connections in conditions where the TCP FIN got lost

The second bit is what really motivated this change *right now*. Since we don't use the signalling websocket after
connection establishment, if the UI closes a video stream (because of a timeout) while the network connection
is really dead, the TCP FIN gets lost and the video streamer never actually realizes the connection is dead.

This leads it to send the video stream forever, wasting bandwidth and CPU.

With this change, the stream will be disconnected if no data is received on the websocket for X seconds (5s by default)