### PR TITLE
fix: rework InboundStreamStatistics to only include what we can actually get from Chrome

### DIFF
--- a/tasks/StreamerTask.cpp
+++ b/tasks/StreamerTask.cpp
@@ -398,18 +398,22 @@ void jsonRead(T& field, Json::Value& json, string const& fieldName) {
     field = jsonConvert<T>(json[fieldName]);
 }
 
-InboundStreamStatistics parseInboundStreamStatistics(Json::Value data) {
+InboundStreamStatistics parseInboundStreamStatistics(Json::Value data)
+{
     InboundStreamStatistics ret;
     jsonRead(ret.rx_bytes, data, "bytesReceived");
-    jsonRead(ret.packets_discarded_error_correction, data, "fecPacketsDiscarded");
-    jsonRead(ret.packets_received, data, "fecPacketsReceived");
-    jsonRead(ret.packets_duplicated, data, "packetsDuplicated");
+    jsonRead(ret.packets_received, data, "packetsReceived");
+    jsonRead(ret.packets_lost, data, "packetsLost");
     jsonRead(ret.frames_decoded, data, "framesDecoded");
 
     double last_packet_received_timestamp;
     jsonRead(last_packet_received_timestamp, data, "lastPacketReceivedTimestamp");
     ret.last_packet_received_timestamp =
         base::Time::fromSeconds(last_packet_received_timestamp / 1000);
+
+    jsonRead(ret.picture_loss_indicators_sent, data, "pliCount");
+    jsonRead(ret.full_infra_requests_sent, data, "firCount");
+    jsonRead(ret.nack_sent, data, "nackCount");
 
     return ret;
 }

--- a/video_streamer_webrtcTypes.hpp
+++ b/video_streamer_webrtcTypes.hpp
@@ -43,25 +43,31 @@ namespace video_streamer_webrtc {
      * This is sent by our client(s) and logged here
      */
     struct InboundStreamStatistics {
-        /** Bytes received so far */
         uint64_t rx_bytes = 0;
-        /** How many packets have been received */
         uint64_t packets_received = 0;
-        /** How many duplicate packets have been received */
         uint64_t packets_lost = 0;
-        /** How many frames have been decoded */
         uint64_t frames_decoded = 0;
-
-        /** Timestamp of the last packet received */
         base::Time last_packet_received_timestamp;
 
         /** How many indicators for "picture loss" were sent by the client back
-         * to us */
+         * to us.
+         *
+         * Picture loss is a message sent by the receiver to the emitter to
+         * indicate a frame was lost.
+         */
         uint64_t picture_loss_indicators_sent = 0;
         /** How many I frame request were sent by the client back to us because
-         * of frame loss */
+         * of frame loss
+         *
+         * "I Frames" are full frames in the video compression stream. These are
+         * the number of times the receiver requested a full I frame to recover
+         * from lost data.
+         */
         uint64_t full_infra_requests_sent = 0;
-        /** How many NACKs have been sent by the client back to us */
+        /** How many NACKs have been sent by the client back to us
+         *
+         * NACKs are sent on corrupted data
+         */
         uint64_t nack_sent = 0;
     };
 

--- a/video_streamer_webrtcTypes.hpp
+++ b/video_streamer_webrtcTypes.hpp
@@ -45,12 +45,10 @@ namespace video_streamer_webrtc {
     struct InboundStreamStatistics {
         /** Bytes received so far */
         uint64_t rx_bytes = 0;
-        /** How many packets got discarded because of error correction */
-        uint64_t packets_discarded_error_correction = 0;
         /** How many packets have been received */
         uint64_t packets_received = 0;
         /** How many duplicate packets have been received */
-        uint64_t packets_duplicated = 0;
+        uint64_t packets_lost = 0;
         /** How many frames have been decoded */
         uint64_t frames_decoded = 0;
 
@@ -60,9 +58,6 @@ namespace video_streamer_webrtc {
         /** How many indicators for "picture loss" were sent by the client back
          * to us */
         uint64_t picture_loss_indicators_sent = 0;
-        /** How many indicators for "slice loss" were sent by the client back to
-         * us */
-        uint64_t slice_loss_indicators_sent = 0;
         /** How many I frame request were sent by the client back to us because
          * of frame loss */
         uint64_t full_infra_requests_sent = 0;


### PR DESCRIPTION
Fields are non-standard, but right now I don't care.