### PR TITLE
fix: setting fps

### DIFF
--- a/tasks/StreamerTask.cpp
+++ b/tasks/StreamerTask.cpp
@@ -788,6 +788,8 @@ void StreamerTask::pushFrame(base::samples::frame::Frame const& frame)
         }
     }
     gst_buffer_unref(buffer);
+
+    nextFrameTime = nextFrameTime + frameDuration;
 }
 
 


### PR DESCRIPTION
With this modification the fps will be published at the correct rate. Without the adding tick at the end of the process the `nextFrameTime` would be behind of time, making it publish all the frames until ` time > nextFrameTime + frameDuration`, reseting the process.