### PR TITLE
feat: implement forward error correction and retransmissions

### DIFF
--- a/tasks/StreamerTask.cpp
+++ b/tasks/StreamerTask.cpp
@@ -4,23 +4,23 @@
 
 #include <base-logging/Logging.hpp>
 
-#include <locale.h>
-#include <glib.h>
 #include <glib-unix.h>
-#include <gst/gst.h>
-#include <gst/video/video-info.h>
-#include <gst/sdp/sdp.h>
+#include <glib.h>
 #include <gst/app/app.h>
+#include <gst/gst.h>
+#include <gst/sdp/sdp.h>
+#include <gst/video/video-info.h>
+#include <locale.h>
 
 #define GST_USE_UNSTABLE_API
 #include <gst/webrtc/webrtc.h>
 
-#include <libsoup/soup.h>
 #include <json/json.h>
+#include <libsoup/soup.h>
 #include <string.h>
 
 #ifndef G_SOURCE_FUNC
-#define G_SOURCE_FUNC(f) ((GSourceFunc) (void (*)(void)) (f))
+#define G_SOURCE_FUNC(f) ((GSourceFunc)(void (*)(void))(f))
 #endif
 
 using namespace base;
@@ -29,38 +29,47 @@ using namespace video_streamer_webrtc;
 
 #define RTP_PAYLOAD_TYPE "96"
 
-Receiver *create_receiver(SoupWebsocketConnection * connection, StreamerTask& task);
+Receiver* create_receiver(SoupWebsocketConnection* connection, StreamerTask& task);
 
-GstPadProbeReturn payloader_caps_event_probe_cb (GstPad * pad,
-    GstPadProbeInfo * info, gpointer user_data);
-
-void on_offer_created_cb (GstPromise * promise, gpointer user_data);
-void on_negotiation_needed_cb (GstElement * webrtcbin, gpointer user_data);
-void on_ice_candidate_cb (GstElement * webrtcbin, guint mline_index,
-    gchar * candidate, gpointer user_data);
-
-void soup_websocket_message_cb (SoupWebsocketConnection * connection,
-    SoupWebsocketDataType data_type, GBytes * message, gpointer user_data);
-void soup_websocket_closed_cb (SoupWebsocketConnection * connection,
+GstPadProbeReturn payloader_caps_event_probe_cb(GstPad* pad,
+    GstPadProbeInfo* info,
     gpointer user_data);
 
-void soup_http_handler (SoupServer * soup_server, SoupMessage * message,
-    const char *path, GHashTable * query, SoupClientContext * client_context,
+void on_offer_created_cb(GstPromise* promise, gpointer user_data);
+void on_negotiation_needed_cb(GstElement* webrtcbin, gpointer user_data);
+void on_ice_candidate_cb(GstElement* webrtcbin,
+    guint mline_index,
+    gchar* candidate,
     gpointer user_data);
 
-struct video_streamer_webrtc::Receiver
-{
+void soup_websocket_message_cb(SoupWebsocketConnection* connection,
+    SoupWebsocketDataType data_type,
+    GBytes* message,
+    gpointer user_data);
+void soup_websocket_closed_cb(SoupWebsocketConnection* connection, gpointer user_data);
+
+void soup_http_handler(SoupServer* soup_server,
+    SoupMessage* message,
+    const char* path,
+    GHashTable* query,
+    SoupClientContext* client_context,
+    gpointer user_data);
+
+struct video_streamer_webrtc::Receiver {
     StreamerTask* task;
 
-    SoupWebsocketConnection *connection = nullptr;
 
-    GstElement *pipeline = nullptr;
-    GstElement *webrtcbin = nullptr;
-    GstAppSrc *appsrc = nullptr;
+    SoupWebsocketConnection* connection = nullptr;
+
+    GstElement* pipeline = nullptr;
+    GstElement* webrtcbin = nullptr;
+    GstElement* rtprtxsend = nullptr;
+    GstAppSrc* appsrc = nullptr;
 
     ClientStatistics stats;
 
-    Receiver() {
+    Receiver()
+    {
         stats.time = Time::now();
     }
     Receiver(Receiver const&) = delete;
@@ -68,33 +77,37 @@ struct video_streamer_webrtc::Receiver
     ~Receiver()
     {
         if (pipeline) {
-            gst_element_set_state (GST_ELEMENT (pipeline), GST_STATE_NULL);
-            gst_object_unref (GST_OBJECT (webrtcbin));
-            gst_object_unref (GST_OBJECT (appsrc));
-            gst_object_unref (GST_OBJECT (pipeline));
+            gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_NULL);
+            gst_object_unref(GST_OBJECT(webrtcbin));
+            gst_object_unref(GST_OBJECT(appsrc));
+            gst_object_unref(GST_OBJECT(pipeline));
         }
 
         if (connection)
-            g_object_unref (G_OBJECT (connection));
+            g_object_unref(G_OBJECT(connection));
     }
 };
 
 /* This function is called when an error message is posted on the bus */
-static void error_cb (GstBus *bus, GstMessage *msg, StreamerTask *task) {
-    GError *err;
-    gchar *debug_info;
+static void error_cb(GstBus* bus, GstMessage* msg, StreamerTask* task)
+{
+    GError* err;
+    gchar* debug_info;
 
     /* Print error details on the screen */
-    gst_message_parse_error (msg, &err, &debug_info);
-    g_printerr ("Error received from element %s: %s\n", GST_OBJECT_NAME (msg->src), err->message);
-    g_printerr ("Debugging information: %s\n", debug_info ? debug_info : "none");
-    g_clear_error (&err);
-    g_free (debug_info);
+    gst_message_parse_error(msg, &err, &debug_info);
+    g_printerr("Error received from element %s: %s\n",
+        GST_OBJECT_NAME(msg->src),
+        err->message);
+    g_printerr("Debugging information: %s\n", debug_info ? debug_info : "none");
+    g_clear_error(&err);
+    g_free(debug_info);
     task->emitGstreamerError();
 }
 
-static GstVideoFormat frameModeToGSTFormat(base::samples::frame::frame_mode_t format) {
-    switch(format) {
+static GstVideoFormat frameModeToGSTFormat(base::samples::frame::frame_mode_t format)
+{
+    switch (format) {
         case base::samples::frame::MODE_RGB:
             return GST_VIDEO_FORMAT_RGB;
         case base::samples::frame::MODE_BGR:
@@ -110,86 +123,94 @@ static GstVideoFormat frameModeToGSTFormat(base::samples::frame::frame_mode_t fo
     }
 }
 
-Receiver* create_receiver(SoupWebsocketConnection * connection, StreamerTask& task)
+Receiver* create_receiver(SoupWebsocketConnection* connection, StreamerTask& task)
 {
     unique_ptr<Receiver> receiver(new Receiver());
     receiver->connection = connection;
-    g_object_ref (G_OBJECT (connection));
+    g_object_ref(G_OBJECT(connection));
 
-    g_signal_connect (G_OBJECT (connection), "message",
-        G_CALLBACK (soup_websocket_message_cb), (gpointer) receiver.get());
+    g_signal_connect(G_OBJECT(connection),
+        "message",
+        G_CALLBACK(soup_websocket_message_cb),
+        (gpointer)receiver.get());
 
     auto encoding = task.getEncoding();
     std::ostringstream pipelineDefinition;
-    pipelineDefinition
-        << "webrtcbin name=webrtcbin appsrc do-timestamp=TRUE is-live=true name=src "
-        << "! videoconvert "
-        << "! " << encoding.encoder_element << " "
-        << "! " << encoding.payload_element << " ";
+    pipelineDefinition << "webrtcbin latency=5000 name=webrtcbin appsrc "
+                          "do-timestamp=TRUE is-live=true name=src "
+                       << "! videoconvert "
+                       << "! " << encoding.encoder_element << " "
+                       << "! " << encoding.payload_element << " name=videopay ";
     if (encoding.mtu) {
         pipelineDefinition << "mtu=" << encoding.mtu << " ";
     }
 
-    pipelineDefinition
-        << "! application/x-rtp,media=video,encoding-name=" << encoding.encoder_name
-        <<    ",payload=" << RTP_PAYLOAD_TYPE
-        << "! webrtcbin.";
+    pipelineDefinition << "! application/x-rtp,media=video,encoding-name="
+                       << encoding.encoder_name << ",payload=" << RTP_PAYLOAD_TYPE
+                       << "! webrtcbin.";
 
     LOG_INFO_S << "using pipeline: " << pipelineDefinition.str() << std::endl;
 
     GError* error = nullptr;
     GstElement* pipeline = gst_parse_launch(pipelineDefinition.str().c_str(), &error);
     if (error) {
-        LOG_ERROR_S << "could not create WebRTC pipeline: "
-                    << error->message << std::endl;
-        g_error_free (error);
+        LOG_ERROR_S << "could not create WebRTC pipeline: " << error->message
+                    << std::endl;
+        g_error_free(error);
         return nullptr;
     }
 
     receiver->pipeline = pipeline;
-    receiver->webrtcbin =
-        gst_bin_get_by_name (GST_BIN (receiver->pipeline), "webrtcbin");
-    g_assert (receiver->webrtcbin != NULL);
+    receiver->webrtcbin = gst_bin_get_by_name(GST_BIN(receiver->pipeline), "webrtcbin");
+    g_assert(receiver->webrtcbin != NULL);
     receiver->appsrc =
-        (GstAppSrc*)gst_bin_get_by_name (GST_BIN (receiver->pipeline), "src");
-    g_assert (receiver->appsrc != NULL);
+        (GstAppSrc*)gst_bin_get_by_name(GST_BIN(receiver->pipeline), "src");
+    g_assert(receiver->appsrc != NULL);
 
     auto stun_server = task.getSTUNServer();
     if (!stun_server.empty()) {
         g_object_set(receiver->webrtcbin, "stun-server", stun_server.c_str(), NULL);
     }
 
-    g_signal_connect(receiver->webrtcbin, "on-negotiation-needed",
-        G_CALLBACK (on_negotiation_needed_cb), (gpointer) receiver.get());
-    g_signal_connect(receiver->webrtcbin, "on-ice-candidate",
-        G_CALLBACK (on_ice_candidate_cb), (gpointer) receiver.get());
 
-    auto bus = gst_element_get_bus (receiver->pipeline);
-    gst_bus_add_signal_watch (bus);
-    g_signal_connect(G_OBJECT (bus), "message::error", (GCallback)error_cb,
+    g_signal_connect(receiver->webrtcbin,
+        "on-negotiation-needed",
+        G_CALLBACK(on_negotiation_needed_cb),
+        (gpointer)receiver.get());
+    g_signal_connect(receiver->webrtcbin,
+        "on-ice-candidate",
+        G_CALLBACK(on_ice_candidate_cb),
+        (gpointer)receiver.get());
+
+    auto bus = gst_element_get_bus(receiver->pipeline);
+    gst_bus_add_signal_watch(bus);
+    g_signal_connect(G_OBJECT(bus),
+        "message::error",
+        (GCallback)error_cb,
         receiver->task);
-    gst_object_unref (bus);
+    gst_object_unref(bus);
 
     return receiver.release();
 }
 
-void
-on_offer_created_cb (GstPromise * promise, gpointer user_data)
+void on_offer_created_cb(GstPromise* promise, gpointer user_data)
 {
-    Receiver *receiver = (Receiver *) user_data;
-    GstStructure const* reply = gst_promise_get_reply (promise);
-    GstWebRTCSessionDescription *offer = NULL;
-    gst_structure_get (reply, "offer", GST_TYPE_WEBRTC_SESSION_DESCRIPTION, &offer, NULL);
-    gst_promise_unref (promise);
+    Receiver* receiver = (Receiver*)user_data;
+    GstStructure const* reply = gst_promise_get_reply(promise);
+    GstWebRTCSessionDescription* offer = NULL;
+    gst_structure_get(reply, "offer", GST_TYPE_WEBRTC_SESSION_DESCRIPTION, &offer, NULL);
+    gst_promise_unref(promise);
 
-    GstPromise* local_desc_promise = gst_promise_new ();
-    g_signal_emit_by_name (receiver->webrtcbin, "set-local-description",
-        offer, local_desc_promise);
-    gst_promise_interrupt (local_desc_promise);
-    gst_promise_unref (local_desc_promise);
+    GstPromise* local_desc_promise = gst_promise_new();
+    g_signal_emit_by_name(receiver->webrtcbin,
+        "set-local-description",
+        offer,
+        local_desc_promise);
+    gst_promise_interrupt(local_desc_promise);
+    gst_promise_unref(local_desc_promise);
 
-    gchar* sdp_string = gst_sdp_message_as_text (offer->sdp);
-    g_print ("Negotiation offer created:\n%s\n", sdp_string);
+    gchar* sdp_string = gst_sdp_message_as_text(offer->sdp);
+    g_print("Negotiation offer created:\n%s\n", sdp_string);
 
     Json::Value sdp_data;
     sdp_data["type"] = "offer";
@@ -201,27 +222,29 @@ on_offer_created_cb (GstPromise * promise, gpointer user_data)
 
     Json::FastWriter writer;
     string json_string = writer.write(sdp);
-    soup_websocket_connection_send_text (receiver->connection, json_string.c_str());
-    gst_webrtc_session_description_free (offer);
+    soup_websocket_connection_send_text(receiver->connection, json_string.c_str());
+    gst_webrtc_session_description_free(offer);
 }
 
-void on_negotiation_needed_cb (GstElement * webrtcbin, gpointer user_data)
+void on_negotiation_needed_cb(GstElement* webrtcbin, gpointer user_data)
 {
-    GstPromise *promise;
-    Receiver *receiver = (Receiver *) user_data;
+    GstPromise* promise;
+    Receiver* receiver = (Receiver*)user_data;
 
-    g_print ("Creating negotiation offer\n");
+    g_print("Creating negotiation offer\n");
 
-    promise = gst_promise_new_with_change_func (on_offer_created_cb,
-        (gpointer) receiver, NULL);
-    g_signal_emit_by_name (G_OBJECT (webrtcbin), "create-offer", NULL, promise);
+    promise =
+        gst_promise_new_with_change_func(on_offer_created_cb, (gpointer)receiver, NULL);
+    g_signal_emit_by_name(G_OBJECT(webrtcbin), "create-offer", NULL, promise);
+
 }
 
-
-void on_ice_candidate_cb (G_GNUC_UNUSED GstElement * webrtcbin, guint mline_index,
-    gchar * candidate, gpointer user_data)
+void on_ice_candidate_cb(G_GNUC_UNUSED GstElement* webrtcbin,
+    guint mline_index,
+    gchar* candidate,
+    gpointer user_data)
 {
-    Receiver *receiver = (Receiver *) user_data;
+    Receiver* receiver = (Receiver*)user_data;
 
     Json::Value ice_data;
     ice_data["sdpMLineIndex"] = mline_index;
@@ -233,7 +256,7 @@ void on_ice_candidate_cb (G_GNUC_UNUSED GstElement * webrtcbin, guint mline_inde
 
     Json::FastWriter writer;
     string json_string = writer.write(ice);
-    soup_websocket_connection_send_text (receiver->connection, json_string.c_str());
+    soup_websocket_connection_send_text(receiver->connection, json_string.c_str());
 }
 
 static void handleSDPMessage(Receiver* receiver, Json::Value data);
@@ -241,11 +264,12 @@ static void handleICEMessage(Receiver* receiver, Json::Value data);
 static void handleStatsMessage(Receiver* receiver, Json::Value data);
 static InboundStreamStatistics parseInboundStreamStatistics(Json::Value data);
 
-void
-soup_websocket_message_cb (G_GNUC_UNUSED SoupWebsocketConnection * connection,
-    SoupWebsocketDataType data_type, GBytes * message, gpointer user_data)
+void soup_websocket_message_cb(G_GNUC_UNUSED SoupWebsocketConnection* connection,
+    SoupWebsocketDataType data_type,
+    GBytes* message,
+    gpointer user_data)
 {
-    Receiver *receiver = (Receiver *) user_data;
+    Receiver* receiver = (Receiver*)user_data;
 
     Json::Value json;
     switch (data_type) {
@@ -253,23 +277,21 @@ soup_websocket_message_cb (G_GNUC_UNUSED SoupWebsocketConnection * connection,
             LOG_ERROR_S << "Received unknown binary message, ignoring" << std::endl;
             return;
 
-        case SOUP_WEBSOCKET_DATA_TEXT:
-            {
-                gsize size;
-                char* gdata = (char*)g_bytes_get_data(message, &size);
-                Json::CharReaderBuilder rbuilder;
-                std::unique_ptr<Json::CharReader> const reader(rbuilder.newCharReader());
+        case SOUP_WEBSOCKET_DATA_TEXT: {
+            gsize size;
+            char* gdata = (char*)g_bytes_get_data(message, &size);
+            Json::CharReaderBuilder rbuilder;
+            std::unique_ptr<Json::CharReader> const reader(rbuilder.newCharReader());
 
-                string errors;
-                if (!reader->parse(gdata, gdata + size, &json, &errors)) {
-                    LOG_ERROR_S << "invalid document received " << errors << std::endl;
-                    return;
-                }
+            string errors;
+            if (!reader->parse(gdata, gdata + size, &json, &errors)) {
+                LOG_ERROR_S << "invalid document received " << errors << std::endl;
+                return;
             }
-            break;
+        } break;
 
         default:
-            g_assert_not_reached ();
+            g_assert_not_reached();
     }
 
     if (json["type"].isNull()) {
@@ -308,7 +330,8 @@ soup_websocket_message_cb (G_GNUC_UNUSED SoupWebsocketConnection * connection,
     }
 }
 
-void handleSDPMessage(Receiver* receiver, Json::Value data) {
+void handleSDPMessage(Receiver* receiver, Json::Value data)
+{
     if (data["type"].isNull()) {
         LOG_ERROR_S << "received SDP message without a 'type' field" << std::endl;
         return;
@@ -316,7 +339,8 @@ void handleSDPMessage(Receiver* receiver, Json::Value data) {
 
     string type = data["type"].asString();
     if (type != "answer") {
-        LOG_ERROR_S << "expected SDP message of type 'answer', but got " << type << std::endl;
+        LOG_ERROR_S << "expected SDP message of type 'answer', but got " << type
+                    << std::endl;
         return;
     }
 
@@ -329,26 +353,25 @@ void handleSDPMessage(Receiver* receiver, Json::Value data) {
 
     GstSDPMessage* sdpMsg;
     int ret = gst_sdp_message_new(&sdpMsg);
-    g_assert_cmphex (ret, ==, GST_SDP_OK);
-    ret = gst_sdp_message_parse_buffer ((guint8 *)sdp.c_str(), sdp.size(), sdpMsg);
+    g_assert_cmphex(ret, ==, GST_SDP_OK);
+    ret = gst_sdp_message_parse_buffer((guint8*)sdp.c_str(), sdp.size(), sdpMsg);
     if (ret != GST_SDP_OK) {
         LOG_ERROR_S << "could not parse SDP string: " << sdp << std::endl;
         return;
     }
 
-    GstWebRTCSessionDescription *answer =
+    GstWebRTCSessionDescription* answer =
         gst_webrtc_session_description_new(GST_WEBRTC_SDP_TYPE_ANSWER, sdpMsg);
-    g_assert_nonnull (answer);
+    g_assert_nonnull(answer);
 
-    GstPromise *promise = gst_promise_new();
-    g_signal_emit_by_name (
-        receiver->webrtcbin, "set-remote-description", answer, promise
-    );
-    gst_promise_interrupt (promise);
-    gst_promise_unref (promise);
+    GstPromise* promise = gst_promise_new();
+    g_signal_emit_by_name(receiver->webrtcbin, "set-remote-description", answer, promise);
+    gst_promise_interrupt(promise);
+    gst_promise_unref(promise);
 }
 
-void handleICEMessage(Receiver* receiver, Json::Value data) {
+void handleICEMessage(Receiver* receiver, Json::Value data)
+{
     if (data["sdpMLineIndex"].isNull()) {
         LOG_ERROR_S << "received ICE message without mline index" << std::endl;
         return;
@@ -360,44 +383,51 @@ void handleICEMessage(Receiver* receiver, Json::Value data) {
         return;
     }
     string candidate = data["candidate"].asString();
-    g_print ("Received ICE candidate with mline index %u; candidate: %s\n",
-        mline_index, candidate.c_str());
+    g_print("Received ICE candidate with mline index %u; candidate: %s\n",
+        mline_index,
+        candidate.c_str());
 
-    g_signal_emit_by_name(receiver->webrtcbin, "add-ice-candidate",
-        mline_index, candidate.c_str());
+    g_signal_emit_by_name(receiver->webrtcbin,
+        "add-ice-candidate",
+        mline_index,
+        candidate.c_str());
 }
 
-void handleStatsMessage(Receiver* receiver, Json::Value data) {
+void handleStatsMessage(Receiver* receiver, Json::Value data)
+{
     ClientStatistics stats;
     stats.time = base::Time::now();
 
     for (unsigned int i = 0; i < data.size(); ++i) {
         if (data[i].get("type", "").asString() == "inbound-rtp") {
             stats.inbound_stream_statistics.push_back(
-                parseInboundStreamStatistics(data[i])
-            );
+                parseInboundStreamStatistics(data[i]));
         }
     }
 
     receiver->stats = stats;
 }
 
-template<typename T> T jsonConvert(Json::Value const& value);
-template<> string jsonConvert<string>(Json::Value const& value) {
+template <typename T> T jsonConvert(Json::Value const& value);
+template <> string jsonConvert<string>(Json::Value const& value)
+{
     return value.asString();
 }
-template<> double jsonConvert<double>(Json::Value const& value) {
+template <> double jsonConvert<double>(Json::Value const& value)
+{
     return value.asDouble();
 }
-template<> float jsonConvert<float>(Json::Value const& value) {
+template <> float jsonConvert<float>(Json::Value const& value)
+{
     return value.asFloat();
 }
-template<> uint64_t jsonConvert<uint64_t>(Json::Value const& value) {
+template <> uint64_t jsonConvert<uint64_t>(Json::Value const& value)
+{
     return value.asLargestUInt();
 }
 
-template<typename T>
-void jsonRead(T& field, Json::Value& json, string const& fieldName) {
+template <typename T> void jsonRead(T& field, Json::Value& json, string const& fieldName)
+{
     if (json[fieldName].isNull()) {
         return;
     }
@@ -425,27 +455,28 @@ InboundStreamStatistics parseInboundStreamStatistics(Json::Value data)
     return ret;
 }
 
-void
-soup_websocket_closed_cb (SoupWebsocketConnection * connection,
-    gpointer user_data)
+void soup_websocket_closed_cb(SoupWebsocketConnection* connection, gpointer user_data)
 {
     ((StreamerTask*)user_data)->deregisterReceiver(connection);
-    g_print ("Closed websocket connection %p\n", (gpointer) connection);
+    g_print("Closed websocket connection %p\n", (gpointer)connection);
 }
 
-void
-soup_websocket_handler (G_GNUC_UNUSED SoupServer * server,
-    SoupWebsocketConnection * connection, G_GNUC_UNUSED const char *path,
-    G_GNUC_UNUSED SoupClientContext * client_context, gpointer _task)
+void soup_websocket_handler(G_GNUC_UNUSED SoupServer* server,
+    SoupWebsocketConnection* connection,
+    G_GNUC_UNUSED const char* path,
+    G_GNUC_UNUSED SoupClientContext* client_context,
+    gpointer _task)
 {
     auto task = (StreamerTask*)_task;
     if (task->serverIsPaused()) {
         return;
     }
 
-    g_print ("Processing new websocket connection %p", (gpointer) connection);
-    g_signal_connect (G_OBJECT (connection), "closed",
-        G_CALLBACK (soup_websocket_closed_cb), task);
+    g_print("Processing new websocket connection %p", (gpointer)connection);
+    g_signal_connect(G_OBJECT(connection),
+        "closed",
+        G_CALLBACK(soup_websocket_closed_cb),
+        task);
 
     auto receiver = create_receiver(connection, *task);
     if (receiver) {
@@ -458,15 +489,17 @@ soup_websocket_handler (G_GNUC_UNUSED SoupServer * server,
 }
 
 const Encoding KNOWN_ENCODERS[] = {
-    { VP8, "vp8enc", "rtpvp8pay", "VP8" },
-    { VAAPI_VP8, "vaapivp8enc", "rtpvp8pay", "VP8" },
-    { H264, "x264enc", "rtph264pay", "H264" },
-    { VAAPI_H264, "vaapih264enc ! video/x-h264,profile=constrained-baseline",
-                  "rtph264pay", "H264" },
-    { CUSTOM_ENCODING, "", "", "" }
+    {            VP8,             "vp8enc",  "rtpvp8pay","VP8"                                                                              },
+    {      VAAPI_VP8,                             "vaapivp8enc",  "rtpvp8pay",  "VP8"},
+    {           H264,                                 "x264enc", "rtph264pay", "H264"},
+    {     VAAPI_H264,
+     "vaapih264enc ! video/x-h264,profile=constrained-baseline", "rtph264pay",
+     "H264"                                                                          },
+    {CUSTOM_ENCODING,                                        "",           "",     ""}
 };
 
-static Encoding encoderInfo(PREDEFINED_ENCODER encoder) {
+static Encoding encoderInfo(PREDEFINED_ENCODER encoder)
+{
     for (Encoding const* it = KNOWN_ENCODERS; it->encoder != CUSTOM_ENCODING; ++it) {
         if (it->encoder == encoder) {
             return *it;
@@ -474,7 +507,6 @@ static Encoding encoderInfo(PREDEFINED_ENCODER encoder) {
     }
     throw std::invalid_argument("no information for given encoder");
 }
-
 
 StreamerTask::StreamerTask(std::string const& name)
     : StreamerTaskBase(name)
@@ -498,7 +530,7 @@ StreamerTask::~StreamerTask()
 
 bool StreamerTask::configureHook()
 {
-    if (! StreamerTaskBase::configureHook())
+    if (!StreamerTaskBase::configureHook())
         return false;
 
     frameDuration = base::Time::fromSeconds(1) / _fps.get();
@@ -519,22 +551,29 @@ bool StreamerTask::configureHook()
     encoding.mtu = userEncoding.mtu;
 
     serverPaused = true;
-    gstThread = std::thread([this](){
+    gstThread = std::thread([this]() {
         maincontext = g_main_context_new();
         g_main_context_push_thread_default(maincontext);
-        mainloop = g_main_loop_new (maincontext, false);
-        g_assert (mainloop != NULL);
+        mainloop = g_main_loop_new(maincontext, false);
+        g_assert(mainloop != NULL);
 
         auto soup_server =
-            soup_server_new (SOUP_SERVER_SERVER_HEADER, "webrtc-soup-server", NULL);
-        soup_server_add_websocket_handler (soup_server, "/ws", NULL, NULL,
-            soup_websocket_handler, (gpointer) this, NULL);
-        soup_server_listen_all (soup_server, _port.get(),
-            (SoupServerListenOptions) 0, NULL);
+            soup_server_new(SOUP_SERVER_SERVER_HEADER, "webrtc-soup-server", NULL);
+        soup_server_add_websocket_handler(soup_server,
+            "/ws",
+            NULL,
+            NULL,
+            soup_websocket_handler,
+            (gpointer)this,
+            NULL);
+        soup_server_listen_all(soup_server,
+            _port.get(),
+            (SoupServerListenOptions)0,
+            NULL);
 
         g_main_loop_run(mainloop);
 
-        g_object_unref (G_OBJECT (soup_server));
+        g_object_unref(G_OBJECT(soup_server));
         g_main_loop_unref(mainloop);
         g_main_context_unref(maincontext);
         mainloop = nullptr;
@@ -544,7 +583,7 @@ bool StreamerTask::configureHook()
 }
 bool StreamerTask::startHook()
 {
-    if (! StreamerTaskBase::startHook())
+    if (!StreamerTaskBase::startHook())
         return false;
     hasFrame = false;
     hasGstreamerError = false;
@@ -621,16 +660,13 @@ void StreamerTask::queueIdleCallback(GSourceFunc callback)
 
 void StreamerTask::updateHook()
 {
-    if (hasGstreamerError)
-    {
+    if (hasGstreamerError) {
         exception(GSTREAMER_ERROR);
     }
-    else if (hasFrame)
-    {
+    else if (hasFrame) {
         queueIdleCallback(G_SOURCE_FUNC(pushPendingFramesCallback));
     }
-    else if (waitFirstFrame())
-    {
+    else if (waitFirstFrame()) {
         queueIdleCallback(G_SOURCE_FUNC(startReceiversCallback));
     }
 
@@ -642,7 +678,6 @@ void StreamerTask::errorHook()
 {
     StreamerTaskBase::errorHook();
 }
-
 
 void StreamerTask::stopHook()
 {
@@ -666,18 +701,17 @@ void StreamerTask::registerReceiver(Receiver* receiver)
         startReceiver(*receiver);
     else
         g_print("Waiting for first frame before starting %p\n", receiver->connection);
-
 }
 void StreamerTask::startReceivers()
 {
-    for (auto& receiver: receivers) {
+    for (auto& receiver : receivers) {
         startReceiver(*receiver.second);
     }
 }
 void StreamerTask::startReceiver(Receiver& receiver)
 {
     GstVideoInfo info;
-    int width  = getImageWidth();
+    int width = getImageWidth();
     int height = getImageHeight();
     GstVideoFormat gstFormat = frameModeToGSTFormat(getImageMode());
     gst_video_info_set_format(&info, gstFormat, width, height);
@@ -687,7 +721,7 @@ void StreamerTask::startReceiver(Receiver& receiver)
     gst_caps_unref(caps);
     gst_app_src_set_max_bytes(receiver.appsrc, imageByteSize * 5);
 
-    gst_element_set_state (receiver.pipeline, GST_STATE_PLAYING);
+    gst_element_set_state(receiver.pipeline, GST_STATE_PLAYING);
     g_print("Started %p\n", receiver.connection);
 
     baseTime = nextFrameTime;
@@ -701,7 +735,8 @@ void StreamerTask::deregisterReceiver(SoupWebsocketConnection* connection)
         receivers.erase(it);
     }
 }
-void StreamerTask::clearAllReceivers() {
+void StreamerTask::clearAllReceivers()
+{
     while (!receivers.empty()) {
         delete receivers.begin()->second;
         receivers.erase(receivers.begin());
@@ -736,7 +771,8 @@ bool StreamerTask::waitFirstFrame()
     return true;
 }
 
-void StreamerTask::configureFrameParameters(base::samples::frame::Frame const& frame) {
+void StreamerTask::configureFrameParameters(base::samples::frame::Frame const& frame)
+{
     imageWidth = frame.getWidth();
     imageHeight = frame.getHeight();
     imageMode = frame.getFrameMode();
@@ -755,8 +791,9 @@ void StreamerTask::pushFrame(base::samples::frame::Frame const& frame)
     // Validate that format did not change
     if (imageMode != frame.getFrameMode() || imageWidth != frame.getWidth() ||
         imageHeight != frame.getHeight()) {
-        LOG_ERROR_S << "Image parameter(s) changed while playing, "\
-                       "closing connection(s)" << std::endl;
+        LOG_ERROR_S << "Image parameter(s) changed while playing, "
+                       "closing connection(s)"
+                    << std::endl;
         configureFrameParameters(frame);
         clearAllReceivers();
     }
@@ -774,7 +811,7 @@ void StreamerTask::pushFrame(base::samples::frame::Frame const& frame)
         return;
 
     /* Create a buffer to wrap the last received image */
-    GstBuffer *buffer = gst_buffer_new_and_alloc(frame.image.size());
+    GstBuffer* buffer = gst_buffer_new_and_alloc(frame.image.size());
     gst_buffer_fill(buffer, 0, frame.image.data(), frame.image.size());
 
     /* Set its timestamp and duration */
@@ -786,7 +823,7 @@ void StreamerTask::pushFrame(base::samples::frame::Frame const& frame)
     for (auto const& receiver : receivers) {
         auto& appsrc = *(receiver.second->appsrc);
         auto current = gst_app_src_get_current_level_bytes(&appsrc);
-        auto max     = gst_app_src_get_max_bytes(&appsrc);
+        auto max = gst_app_src_get_max_bytes(&appsrc);
         if (current <= max) {
             gst_app_src_push_buffer(&appsrc, gst_buffer_copy(buffer));
         }
@@ -798,7 +835,6 @@ void StreamerTask::pushFrame(base::samples::frame::Frame const& frame)
 
     nextFrameTime = nextFrameTime + frameDuration;
 }
-
 
 int StreamerTask::pushPendingFramesCallback(StreamerTask* task)
 {

--- a/tasks/StreamerTask.cpp
+++ b/tasks/StreamerTask.cpp
@@ -205,15 +205,17 @@ Receiver* create_receiver(SoupWebsocketConnection* connection, StreamerTask& tas
         (GstAppSrc*)gst_bin_get_by_name(GST_BIN(receiver->pipeline), "src");
     g_assert(receiver->appsrc != NULL);
 
-    GstWebRTCICE* ice_agent;
+    gpointer* ice_agent = NULL;
     g_object_get(receiver->webrtcbin, "ice-agent", &ice_agent, NULL);
-    g_object_set(ice_agent, "ice-tcp", transport.use_tcp, NULL);
-    g_object_set(ice_agent, "ice-udp", transport.use_udp, NULL);
-    if (!transport.local_ip_address.empty()) {
-        g_signal_emit_by_name(ice_agent,
-            "add-local-ip-address",
-            transport.local_ip_address.c_str(),
-            NULL);
+    if (ice_agent) {
+        g_object_set(ice_agent, "ice-tcp", transport.use_tcp, NULL);
+        g_object_set(ice_agent, "ice-udp", transport.use_udp, NULL);
+        if (!transport.local_ip_address.empty()) {
+            g_signal_emit_by_name(ice_agent,
+                "add-local-ip-address",
+                transport.local_ip_address.c_str(),
+                NULL);
+        }
     }
 
     auto stun_server = task.getSTUNServer();

--- a/tasks/StreamerTask.hpp
+++ b/tasks/StreamerTask.hpp
@@ -129,6 +129,7 @@ namespace video_streamer_webrtc {
         bool serverIsPaused() const;
 
         std::string getSTUNServer() const;
+        Transport getTransport() const;
         Encoding getEncoding() const;
 
     private:

--- a/tasks/StreamerTask.hpp
+++ b/tasks/StreamerTask.hpp
@@ -4,9 +4,9 @@
 #define VIDEO_STREAMER_WEBRTC_STREAMERTASK_TASK_HPP
 
 #include "video_streamer_webrtc/StreamerTaskBase.hpp"
-#include <libsoup/soup-types.h>
 #include <base/samples/Frame.hpp>
 #include <gst/gstelement.h>
+#include <libsoup/soup-types.h>
 #include <thread>
 
 struct _GMainLoop;
@@ -14,13 +14,16 @@ typedef struct _GMainLoop GMainLoop;
 struct _GHashTable;
 typedef struct _GHashTable GHashTable;
 
-namespace video_streamer_webrtc{
+namespace video_streamer_webrtc {
     struct Receiver;
 
     /*! \class StreamerTask
-     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
-     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
-     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
      *
      * \details
      * The name of a TaskContext is primarily defined via:
@@ -29,31 +32,33 @@ namespace video_streamer_webrtc{
          task('custom_task_name','video_streamer_webrtc::StreamerTask')
      end
      \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
      */
-    class StreamerTask : public StreamerTaskBase
-    {
-	friend class StreamerTaskBase;
+    class StreamerTask : public StreamerTaskBase {
+        friend class StreamerTaskBase;
+
     protected:
-
     public:
-
         /** TaskContext constructor for StreamerTask
-         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
-         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
          */
         StreamerTask(std::string const& name = "video_streamer_webrtc::StreamerTask");
 
         /** TaskContext constructor for StreamerTask
-         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
-         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable for nameservices. \param engine The RTT Execution engine to be
+         * used for this task, which serialises the execution of all commands, programs,
+         * state machines and incoming events for a task.
          *
          */
         StreamerTask(std::string const& name, RTT::ExecutionEngine* engine);
 
         /** Default deconstructor of StreamerTask
          */
-	~StreamerTask();
+        ~StreamerTask();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
@@ -143,9 +148,9 @@ namespace video_streamer_webrtc{
         base::Time nextFrameTime;
 
         int argc = 0;
-        const char* argv[1] = { "webrtc-streamer "};
-        GMainContext *maincontext = nullptr;
-        GMainLoop *mainloop = nullptr;
+        const char* argv[1] = {"webrtc-streamer "};
+        GMainContext* maincontext = nullptr;
+        GMainLoop* mainloop = nullptr;
 
         typedef std::map<SoupWebsocketConnection*, Receiver*> ReceiverMap;
         ReceiverMap receivers;

--- a/video_streamer_webrtc.orogen
+++ b/video_streamer_webrtc.orogen
@@ -45,6 +45,9 @@ task_context "StreamerTask" do
     # The port on which the embedded server is listening
     property "port", "int", 57_778
 
+    # Transport configuration
+    property "transport", "video_streamer_webrtc/Transport"
+
     # Encoding configuration (defaults to VP8)
     property "encoding", "video_streamer_webrtc/Encoding"
 

--- a/video_streamer_webrtcTypes.hpp
+++ b/video_streamer_webrtcTypes.hpp
@@ -21,6 +21,15 @@ namespace video_streamer_webrtc {
         float forward_error_correction = 0;
         /** Whether to allow retransmissions */
         bool allow_retransmissions = false;
+        /** Whether TCP may be used to connect the peers */
+        bool use_tcp = false;
+        /** Whether UDP may be used to connect the peers */
+        bool use_udp = true;
+        /** The local address to advertise
+         *
+         * Setting this cancels the ICE process
+         */
+        std::string local_ip_address;
     };
 
     /** Definition of the underlying encoder to be used in the webrtc connections */

--- a/video_streamer_webrtcTypes.hpp
+++ b/video_streamer_webrtcTypes.hpp
@@ -1,14 +1,18 @@
 #ifndef video_streamer_webrtc_TYPES_HPP
 #define video_streamer_webrtc_TYPES_HPP
 
-#include <string>
-#include <stdint.h>
 #include <base/Float.hpp>
 #include <base/Time.hpp>
+#include <stdint.h>
+#include <string>
 
 namespace video_streamer_webrtc {
     enum PREDEFINED_ENCODER {
-        VP8, VAAPI_VP8, H264, VAAPI_H264, CUSTOM_ENCODING
+        VP8,
+        VAAPI_VP8,
+        H264,
+        VAAPI_H264,
+        CUSTOM_ENCODING
     };
 
     /** Definition of the underlying encoder to be used in the webrtc connections */
@@ -80,4 +84,3 @@ namespace video_streamer_webrtc {
 }
 
 #endif
-

--- a/video_streamer_webrtcTypes.hpp
+++ b/video_streamer_webrtcTypes.hpp
@@ -16,6 +16,14 @@ namespace video_streamer_webrtc {
     };
 
     /** Definition of the underlying encoder to be used in the webrtc connections */
+    struct Transport {
+        /** Forward error correction percentage (between 0 and 1). Set to 0 for none. */
+        float forward_error_correction = 0;
+        /** Whether to allow retransmissions */
+        bool allow_retransmissions = false;
+    };
+
+    /** Definition of the underlying encoder to be used in the webrtc connections */
     struct Encoding {
         /** A predefined encoder
          *
@@ -38,7 +46,10 @@ namespace video_streamer_webrtc {
          * If 'encoder' is not CUSTOM_ENCODER, overrides the value set via 'encoder'
          */
         std::string encoder_name;
-        /** MTU of the network link */
+        /** MTU of the network link
+         *
+         * Deprecated, leave to zero and set the MTU in the payloader elements
+         */
         uint16_t mtu = 0;
     };
 


### PR DESCRIPTION
The enabling code is compatible with GStreamer 1.20, but will not work without GStreamer 1.22, at least when
in combination with Chrome.

On top of https://github.com/rock-drivers/drivers-orogen-video_streamer_webrtc/pull/12